### PR TITLE
Fix for Lightning Reflexes

### DIFF
--- a/Zen Den Amends/amend_qualities.xml
+++ b/Zen Den Amends/amend_qualities.xml
@@ -297,8 +297,8 @@
 			<name>Lightning Reflexes</name>
 			<bonus amendoperation="replace">
 				<dodge>1</dodge>
-				<initiative precedence="-1">1</initiative>
-				<initiativepass precedence="-1">1</initiativepass>
+				<initiative>1</initiative>
+				<initiativepass>1</initiativepass>
 			</bonus>
 		</quality>
 		<quality>


### PR DESCRIPTION
Lightning Reflexes does not always stack properly with other initiative increases. This should fix the issue by removing all precedence and thus letting it stack with everything.