### PR TITLE
Cyberdeck/Commlink Fix

### DIFF
--- a/Zen Den Amends/amend_cyberware.xml
+++ b/Zen Den Amends/amend_cyberware.xml
@@ -76,6 +76,9 @@
 			<id>992fbf6b-8f9a-4c27-a527-8705ecc3341f</id>
 			<capacity>4</capacity>
 			<avail>6</avail>
+			<allowsubsystems amendoperation="append">
+				<category>Skullware</category>
+			</allowsubsystems>
 		</cyberware>
 		<cyberware>
 			<!-- Partial Skull  -->
@@ -148,12 +151,28 @@
 		<cyberware>
 			<!-- Commlink  -->
 			<id>6b219dfa-310a-45ab-98af-40a62e2431cf</id>
-			<requireparent />
+			<capacity>2/[2]</capacity>
+			<allowsubsystems>
+				<category>Skullware</category>
+			</allowsubsystems>
+			<subsystems>
+	        	<cyberware>
+	        		<name>Commlink Slot</name>
+		        </cyberware>
+	      	</subsystems>
 		</cyberware>
 		<cyberware>
 			<!-- Cyberdeck  -->
 			<id>754a2083-9d89-4034-b43f-31bd5bb43595</id>
-			<requireparent />
+			<capacity>4/[4]</capacity>
+			<allowsubsystems>
+				<category>Skullware</category>
+			</allowsubsystems>
+			<subsystems>
+	        	<cyberware>
+	        		<name>Cyberdeck Slot</name>
+		        </cyberware>
+	      	</subsystems>
 		</cyberware>
 	</cyberwares>
 </chummer>

--- a/Zen Den Amends/custom_cyberware.xml
+++ b/Zen Den Amends/custom_cyberware.xml
@@ -822,12 +822,52 @@
 			<id>937b4f17-8953-4fd3-8a0b-d53a1c33e253</id>
 			<name>Visualizer</name>
 			<category>Skullware</category>
-			<capacity>[1]]</capacity>
+			<capacity>[1]</capacity>
 			<avail>8</avail>
 			<cost>2000</cost>
 			<source>CF</source>
 			<page>81</page>
 			<requireparent />
 		</cyberware>
+        <cyberware>
+          <id>e58d684d-58c7-4cd8-ae4d-7dacc29ca413</id>
+          <name>Commlink Slot</name>
+          <limit>False</limit>
+          <category>Skullware</category>
+          <ess>0</ess>
+          <capacity>[0]</capacity>
+          <avail>0</avail>
+          <cost>0</cost>
+          <source>ZDR</source>
+          <page>1</page>
+          <allowgear>
+            <gearcategory>Commlinks</gearcategory>
+          </allowgear>
+          <required>
+            <parentdetails>
+                <name>Commlink</name>
+            </parentdetails>
+          </required>
+        </cyberware>
+        <cyberware>
+          <id>c10de60f-9e96-4841-bef5-c97fc331f0de</id>
+          <name>Cyberdeck Slot</name>
+          <limit>False</limit>
+          <category>Skullware</category>
+          <ess>0</ess>
+          <capacity>[0]</capacity>
+          <avail>0</avail>
+          <cost>0</cost>
+          <source>ZDR</source>
+          <page>1</page>
+          <allowgear>
+            <gearcategory>Cyberdecks</gearcategory>
+          </allowgear>
+          <required>
+            <parentdetails>
+                <name>Cyberdeck</name>
+            </parentdetails>
+          </required>
+        </cyberware>
 	</cyberwares>
 </chummer>

--- a/Zen Den Amends/custom_cyberware.xml
+++ b/Zen Den Amends/custom_cyberware.xml
@@ -809,7 +809,7 @@
 			<category>Skullware</category>
 			<capacity>[1]</capacity>
 			<avail>Rating * 2</avail>
-			<cost>Rating * 20000</cost>
+			<cost>Rating * 1000</cost>
 			<source>SR5</source>
 			<page>452</page>
 			<bonus>


### PR DESCRIPTION
Works around the cyberdeck and commlink bugs by adding a Cyberdeck Slot and Commlink Slot to the ware items where you can put the requisite item in.